### PR TITLE
feat: add reusable Docker build workflow

### DIFF
--- a/.github/workflows/anki-docker-publish.yaml
+++ b/.github/workflows/anki-docker-publish.yaml
@@ -1,6 +1,5 @@
 name: Build and Publish Anki Desktop Docker image
 
-
 on:
   push:
     paths:
@@ -8,43 +7,17 @@ on:
       - '.github/workflows/anki-docker-publish.yaml'
   workflow_call:
 
-
 jobs:
   build:
-    runs-on: ubuntu-24.04
     strategy:
       matrix:
         anki_version: [25.02.5]
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - uses: benjlevesque/short-sha@v2.2
-        id: short-sha
-        with:
-          length: 6
-
-      - name: Set up Docker buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push Docker Image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./anki-desktop-docker
-          file: ./anki-desktop-docker/Dockerfile
-          push: true
-          tags: ghcr.io/${{ github.actor }}/anki-desktop-docker:${{ matrix.anki_version }}-${{ steps.short-sha.outputs.sha }} , ghcr.io/${{ github.actor }}/anki-desktop-docker:${{ matrix.anki_version }}-latest
-          build-args: |
-            ANKI_VERSION=${{ matrix.anki_version }}
-
+    uses: ./.github/workflows/docker-build.yaml
+    secrets: inherit
+    with:
+      image_name: anki-desktop-docker
+      context: ./anki-desktop-docker
+      dockerfile: ./anki-desktop-docker/Dockerfile
+      version: ${{ matrix.anki_version }}
+      build_args: |
+        ANKI_VERSION=${{ matrix.anki_version }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,57 @@
+name: Reusable Docker Build
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+      context:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      version:
+        required: false
+        type: string
+        default: latest
+      build_args:
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: benjlevesque/short-sha@v2.2
+        id: short-sha
+        with:
+          length: 6
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.actor }}/${{ inputs.image_name }}:${{ inputs.version }}-${{ steps.short-sha.outputs.sha }}
+            ghcr.io/${{ github.actor }}/${{ inputs.image_name }}:${{ inputs.version }}-latest
+          build-args: ${{ inputs.build_args }}


### PR DESCRIPTION
## Summary
- add reusable workflow to build and push Docker images
- call reusable workflow for Anki image builds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b4bc6dd0832f946585dd87801f81