### PR TITLE
Install Go toolchain in codex image

### DIFF
--- a/openai-codex/Dockerfile
+++ b/openai-codex/Dockerfile
@@ -17,6 +17,12 @@ RUN wget -q ${CODEX_URL} && \
 # ---- Final runtime stage ----
 FROM ubuntu:24.04
 
+ARG TARGETARCH=amd64
+
+ENV GOLANG_VERSION=1.24.5
+ENV GOLANG_AMD64_SHA256=10ad9e86233e74c0f6590fe5426895de6bf388964210eac34a6d83f38918ecdc
+ENV GOLANG_ARM64_SHA256=0df02e6aeb3d3c06c95ff201d575907c736d6c62cfa4b6934c11203f1d600ffa
+
 # Install basic development tools, ca-certificates, and iptables/ipset, then clean up apt cache to reduce image size
 RUN apt-get update && apt-get install -y --no-install-recommends \
   aggregate \
@@ -40,6 +46,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 ENV CODEX_UNSAFE_ALLOW_NO_SANDBOX=1
+
+RUN set -eux; \
+  arch="${TARGETARCH:-amd64}"; \
+  case "$arch" in \
+    arm64) go_sha256="$GOLANG_ARM64_SHA256";; \
+    amd64) go_sha256="$GOLANG_AMD64_SHA256";; \
+    *) echo "unsupported TARGETARCH: $arch" >&2; exit 1;; \
+  esac; \
+  curl -fsSLo /tmp/go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-${arch}.tar.gz"; \
+  echo "${go_sha256} /tmp/go.tgz" | sha256sum -c -; \
+  tar -C /usr/local -xzf /tmp/go.tgz; \
+  rm /tmp/go.tgz; \
+  /usr/local/go/bin/go version
+
+ENV GOPATH=/go
+ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
 
 # Set up project directory
 ENV CODEX_HOME=/workspace/codex


### PR DESCRIPTION
## Summary
- install the Go toolchain in the codex runtime image with architecture-specific verification
- expose GOPATH and Go bin directories on the default PATH

## Testing
- docker build . -t codex-test *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a166b694832f92487a7ed1545d6c