### PR TITLE
Simplify Codex language toolchains

### DIFF
--- a/.github/workflows/openai-codex-publish.yaml
+++ b/.github/workflows/openai-codex-publish.yaml
@@ -18,9 +18,9 @@ jobs:
     with:
       image-name: codex-binary
       context: ./openai-codex/codex-binary
-      version: v0.39.0
+      version: v0.40.0
       build-args: |
-        CODEX_VERSION=rust-v0.39.0
+        CODEX_VERSION=rust-v0.40.0
 
   build-codex:
     needs: build-codex-binary

--- a/openai-codex/Dockerfile
+++ b/openai-codex/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CODEX_BINARY_REF=rust-v0.39.0
+ARG CODEX_BINARY_REF=rust-v0.40.0
 
 FROM ghcr.io/spigell/codex-binary:${CODEX_BINARY_REF} AS codex
 FROM ubuntu:24.04

--- a/openai-codex/Dockerfile
+++ b/openai-codex/Dockerfile
@@ -5,6 +5,10 @@ ARG CODEX_BINARY_REF=rust-v0.39.0
 FROM ghcr.io/spigell/codex-binary:${CODEX_BINARY_REF} AS codex
 FROM ubuntu:24.04
 
+ENV LANG="C.UTF-8"
+ENV HOME=/root
+ENV DEBIAN_FRONTEND=noninteractive
+
 ARG CODEX_BINARY_REF
 
 # Taken from universal image
@@ -93,6 +97,68 @@ RUN set -eux; \
 
 ENV GOPATH=/go
 ENV PATH="${GOPATH}/bin:/usr/local/go/bin:${PATH}"
+
+### PYTHON ###
+
+ARG PYENV_VERSION=v2.5.5
+ARG PYTHON_VERSIONS="3.12.6"
+
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH="${PYENV_ROOT}/bin:${PYENV_ROOT}/shims:${PATH}"
+
+RUN git -c advice.detachedHead=0 clone --branch "$PYENV_VERSION" --depth 1 https://github.com/pyenv/pyenv.git "$PYENV_ROOT" \
+    && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> /etc/profile \
+    && echo 'export PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"' >> /etc/profile \
+    && echo 'eval "$(pyenv init - bash)"' >> /etc/profile \
+    && cd "$PYENV_ROOT" \
+    && src/configure \
+    && make -C src \
+    && for version in $PYTHON_VERSIONS; do pyenv install "$version"; done \
+    && pyenv global "${PYTHON_VERSIONS%% *}" \
+    && rm -rf "$PYENV_ROOT/cache"
+
+ENV PIPX_BIN_DIR=/root/.local/bin
+ENV PATH="${PIPX_BIN_DIR}:${PATH}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pipx=1.4.* \
+    && rm -rf /var/lib/apt/lists/* \
+    && pipx install --pip-args="--no-cache-dir --no-compile" poetry==2.1.* uv==0.7.* \
+    && for pyv in "${PYENV_ROOT}/versions/"*; do \
+         "$pyv/bin/python" -m pip install --no-cache-dir --no-compile --upgrade pip && \
+         "$pyv/bin/pip" install --no-cache-dir --no-compile ruff black mypy pyright isort pytest; \
+       done \
+    && rm -rf /root/.cache/pip ~/.cache/pip ~/.cache/pipx
+
+ENV UV_NO_PROGRESS=1
+
+### NODE & TYPESCRIPT ###
+
+ARG NVM_VERSION=v0.40.2
+ARG NODE_VERSION=22
+
+ENV NVM_DIR=/root/.nvm
+
+RUN git -c advice.detachedHead=0 clone --branch "$NVM_VERSION" --depth 1 https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
+    && echo 'source $NVM_DIR/nvm.sh' >> /etc/profile \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install "$NODE_VERSION" \
+    && nvm alias default "$NODE_VERSION" \
+    && nvm use default \
+    && npm install -g yarn \
+    && yarn global add prettier eslint typescript \
+    && YARN_GLOBAL_BIN="$(yarn global bin)" \
+    && for bin in node yarn; do \
+         ln -sf "$(command -v "$bin")" "/usr/local/bin/$bin"; \
+       done \
+    && for tsbin in prettier eslint tsc tsserver; do \
+         ln -sf "${YARN_GLOBAL_BIN}/$tsbin" "/usr/local/bin/$tsbin"; \
+       done \
+    && yarn cache clean || true \
+    && rm -rf ~/.cache/yarn \
+    && nvm cache clear \
+    && npm cache clean --force || true
+
 ENV CODEX_UNSAFE_ALLOW_NO_SANDBOX=1
 LABEL codex.binary.ref="${CODEX_BINARY_REF}"
 

--- a/openai-codex/README.md
+++ b/openai-codex/README.md
@@ -10,8 +10,8 @@ This directory provides two Dockerfiles:
 ```bash
 docker build \
   -f codex-binary/Dockerfile \
-  --build-arg CODEX_VERSION=rust-v0.39.0 \
-  -t ghcr.io/example/codex-binary:rust-v0.39.0 \
+  --build-arg CODEX_VERSION=rust-v0.40.0 \
+  -t ghcr.io/example/codex-binary:rust-v0.40.0 \
   .
 ```
 
@@ -24,10 +24,10 @@ Build the primary image by referencing the binary image.  The `CODEX_BINARY_IMAG
 ```bash
 docker build \
   -f Dockerfile \
-  --build-arg CODEX_VERSION=rust-v0.39.0 \
+  --build-arg CODEX_VERSION=rust-v0.40.0 \
   --build-arg CODEX_BINARY_IMAGE=ghcr.io/example/codex-binary \
-  --build-arg CODEX_BINARY_REF=rust-v0.39.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-  -t ghcr.io/example/codex:rust-v0.39.0 \
+  --build-arg CODEX_BINARY_REF=rust-v0.40.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  -t ghcr.io/example/codex:rust-v0.40.0 \
   .
 ```
 

--- a/openai-codex/codex-binary/Dockerfile
+++ b/openai-codex/codex-binary/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CODEX_VERSION=rust-v0.39.0
+ARG CODEX_VERSION=rust-v0.40.0
 ARG CODEX_TARBALL=codex-x86_64-unknown-linux-gnu.tar.gz
 ARG CODEX_BINARY_NAME=codex-x86_64-unknown-linux-gnu
 ARG CODEX_BASE_URL=https://github.com/openai/codex/releases/download

--- a/openai-codex/docker-compose.yaml
+++ b/openai-codex/docker-compose.yaml
@@ -6,9 +6,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        CODEX_VERSION: rust-v0.39.0
+        CODEX_VERSION: rust-v0.40.0
         CODEX_BINARY_IMAGE: codex-binary
-        CODEX_BINARY_REF: rust-v0.39.0
+        CODEX_BINARY_REF: rust-v0.40.0
     image: codex:test
     container_name: codex-mini
     command: ["sleep infinity"]


### PR DESCRIPTION
## Summary
- limit pyenv to a single Python 3.12 runtime while retaining the installation loop
- install only Node.js 22 and use Yarn to provide global JS tooling without corepack/pnpm/npx

## Testing
- not run (Dockerfile change only)

------
https://chatgpt.com/codex/tasks/task_e_68d3de36c79c832fbe3c8676a2aa9990