### PR TITLE
chore: update codex image defaults to rust-v0.42.0

### DIFF
--- a/.github/workflows/openai-codex-publish.yaml
+++ b/.github/workflows/openai-codex-publish.yaml
@@ -18,9 +18,9 @@ jobs:
     with:
       image-name: codex-binary
       context: ./openai-codex/codex-binary
-      version: v0.40.0
+      version: v0.42.0
       build-args: |
-        CODEX_VERSION=rust-v0.40.0
+        CODEX_VERSION=rust-v0.42.0
 
   build-codex:
     needs: build-codex-binary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Guidelines
+
+- When updating the Codex version, ensure that every reference in `openai-codex/` (Dockerfiles, README, docker-compose) and the `.github/workflows/openai-codex-publish.yaml` workflow are kept in sync.
+- Document any version bumps or related workflow updates in the PR summary.

--- a/openai-codex/Dockerfile
+++ b/openai-codex/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CODEX_BINARY_REF=rust-v0.40.0
+ARG CODEX_BINARY_REF=rust-v0.42.0
 
 FROM ghcr.io/spigell/codex-binary:${CODEX_BINARY_REF} AS codex
 FROM ubuntu:24.04

--- a/openai-codex/README.md
+++ b/openai-codex/README.md
@@ -10,8 +10,8 @@ This directory provides two Dockerfiles:
 ```bash
 docker build \
   -f codex-binary/Dockerfile \
-  --build-arg CODEX_VERSION=rust-v0.40.0 \
-  -t ghcr.io/example/codex-binary:rust-v0.40.0 \
+  --build-arg CODEX_VERSION=rust-v0.42.0 \
+  -t ghcr.io/example/codex-binary:rust-v0.42.0 \
   .
 ```
 
@@ -24,10 +24,10 @@ Build the primary image by referencing the binary image.  The `CODEX_BINARY_IMAG
 ```bash
 docker build \
   -f Dockerfile \
-  --build-arg CODEX_VERSION=rust-v0.40.0 \
+  --build-arg CODEX_VERSION=rust-v0.42.0 \
   --build-arg CODEX_BINARY_IMAGE=ghcr.io/example/codex-binary \
-  --build-arg CODEX_BINARY_REF=rust-v0.40.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-  -t ghcr.io/example/codex:rust-v0.40.0 \
+  --build-arg CODEX_BINARY_REF=rust-v0.42.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  -t ghcr.io/example/codex:rust-v0.42.0 \
   .
 ```
 

--- a/openai-codex/codex-binary/Dockerfile
+++ b/openai-codex/codex-binary/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CODEX_VERSION=rust-v0.40.0
+ARG CODEX_VERSION=rust-v0.42.0
 ARG CODEX_TARBALL=codex-x86_64-unknown-linux-gnu.tar.gz
 ARG CODEX_BINARY_NAME=codex-x86_64-unknown-linux-gnu
 ARG CODEX_BASE_URL=https://github.com/openai/codex/releases/download

--- a/openai-codex/docker-compose.yaml
+++ b/openai-codex/docker-compose.yaml
@@ -6,9 +6,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        CODEX_VERSION: rust-v0.40.0
+        CODEX_VERSION: rust-v0.42.0
         CODEX_BINARY_IMAGE: codex-binary
-        CODEX_BINARY_REF: rust-v0.40.0
+        CODEX_BINARY_REF: rust-v0.42.0
     image: codex:test
     container_name: codex-mini
     command: ["sleep infinity"]


### PR DESCRIPTION
## Summary
- bump the default CODEX binary reference in the Dockerfile to rust-v0.42.0
- update the codex-binary Dockerfile, docker compose file, and README examples to reference the new version
- update the Codex publish workflow to build the rust-v0.42.0 images and document the sync requirement in AGENTS.md

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f8e47cd8832fa17789878bab9be9