### PR TITLE
chore: bump codex to 0.44.0

### DIFF
--- a/.github/workflows/openai-codex-publish.yaml
+++ b/.github/workflows/openai-codex-publish.yaml
@@ -18,9 +18,9 @@ jobs:
     with:
       image-name: codex-binary
       context: ./openai-codex/codex-binary
-      version: v0.42.0
+      version: v0.44.0
       build-args: |
-        CODEX_VERSION=rust-v0.42.0
+        CODEX_VERSION=rust-v0.44.0
 
   build-codex:
     needs: build-codex-binary

--- a/openai-codex/Dockerfile
+++ b/openai-codex/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CODEX_BINARY_REF=rust-v0.42.0
+ARG CODEX_BINARY_REF=rust-v0.44.0
 
 FROM ghcr.io/spigell/codex-binary:${CODEX_BINARY_REF} AS codex
 FROM ubuntu:24.04

--- a/openai-codex/README.md
+++ b/openai-codex/README.md
@@ -10,8 +10,8 @@ This directory provides two Dockerfiles:
 ```bash
 docker build \
   -f codex-binary/Dockerfile \
-  --build-arg CODEX_VERSION=rust-v0.42.0 \
-  -t ghcr.io/example/codex-binary:rust-v0.42.0 \
+  --build-arg CODEX_VERSION=rust-v0.44.0 \
+  -t ghcr.io/example/codex-binary:rust-v0.44.0 \
   .
 ```
 
@@ -24,10 +24,10 @@ Build the primary image by referencing the binary image.  The `CODEX_BINARY_IMAG
 ```bash
 docker build \
   -f Dockerfile \
-  --build-arg CODEX_VERSION=rust-v0.42.0 \
+  --build-arg CODEX_VERSION=rust-v0.44.0 \
   --build-arg CODEX_BINARY_IMAGE=ghcr.io/example/codex-binary \
-  --build-arg CODEX_BINARY_REF=rust-v0.42.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-  -t ghcr.io/example/codex:rust-v0.42.0 \
+  --build-arg CODEX_BINARY_REF=rust-v0.44.0@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  -t ghcr.io/example/codex:rust-v0.44.0 \
   .
 ```
 

--- a/openai-codex/codex-binary/Dockerfile
+++ b/openai-codex/codex-binary/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-ARG CODEX_VERSION=rust-v0.42.0
+ARG CODEX_VERSION=rust-v0.44.0
 ARG CODEX_TARBALL=codex-x86_64-unknown-linux-gnu.tar.gz
 ARG CODEX_BINARY_NAME=codex-x86_64-unknown-linux-gnu
 ARG CODEX_BASE_URL=https://github.com/openai/codex/releases/download

--- a/openai-codex/docker-compose.yaml
+++ b/openai-codex/docker-compose.yaml
@@ -6,9 +6,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        CODEX_VERSION: rust-v0.42.0
+        CODEX_VERSION: rust-v0.44.0
         CODEX_BINARY_IMAGE: codex-binary
-        CODEX_BINARY_REF: rust-v0.42.0
+        CODEX_BINARY_REF: rust-v0.44.0
     image: codex:test
     container_name: codex-mini
     command: ["sleep infinity"]


### PR DESCRIPTION
## Summary
- update Codex Dockerfiles, docker-compose, and documentation to reference rust-v0.44.0
- align the publish workflow to build and release Codex v0.44.0

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10abacb98832faeaf1924d5bf0a86