### PR TITLE
Add Gemini CLI images and publish workflow

### DIFF
--- a/.github/workflows/gemini-cli-publish.yaml
+++ b/.github/workflows/gemini-cli-publish.yaml
@@ -1,0 +1,35 @@
+name: Build and Publish Gemini CLI images
+
+on:
+  push:
+    paths:
+      - 'gemini-cli/**'
+      - 'gemini-cli-workbench/**'
+      - '.github/workflows/gemini-cli-publish.yaml'
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-gemini-cli:
+    uses: spigell/my-shared-workflows/.github/workflows/docker-build-release.yaml@main
+    secrets: inherit
+    with:
+      image-name: gemini-cli
+      context: ./gemini-cli
+      version: 0.8.1
+      build-args: |
+        GEMINI_CLI_VERSION=0.8.1
+
+  build-gemini-cli-workbench:
+    needs: build-gemini-cli
+    uses: spigell/my-shared-workflows/.github/workflows/docker-build-release.yaml@main
+    secrets: inherit
+    with:
+      image-name: gemini-cli-workbench
+      context: ./gemini-cli-workbench
+      version: ${{ needs.build-gemini-cli.outputs.version }}
+      build-args: |
+        GEMINI_CLI_TAG=${{ needs.build-gemini-cli.outputs.sha-tag }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # my-images
+
+## Available images
+
+- **gemini-cli**: Minimal devcontainer-based image with the Google Gemini CLI preinstalled.
+- **gemini-cli-workbench**: Extends `gemini-cli` with common terminal tooling for interactive workflows.

--- a/gemini-cli-workbench/.dockerignore
+++ b/gemini-cli-workbench/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/gemini-cli-workbench/Dockerfile
+++ b/gemini-cli-workbench/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1.7
+
+ARG GEMINI_CLI_TAG=latest
+FROM ghcr.io/spigell/gemini-cli:${GEMINI_CLI_TAG}
+
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+
+USER root
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash-completion \
+        ca-certificates \
+        curl \
+        git \
+        jq \
+        less \
+        openssh-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER node
+WORKDIR /workspace
+
+ENTRYPOINT ["bash", "-lc"]
+CMD ["gemini --help"]

--- a/gemini-cli/.dockerignore
+++ b/gemini-cli/.dockerignore
@@ -1,0 +1,2 @@
+*
+!Dockerfile

--- a/gemini-cli/Dockerfile
+++ b/gemini-cli/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7
+
+ARG VARIANT=22-bookworm
+FROM mcr.microsoft.com/devcontainers/typescript-node:${VARIANT}
+
+SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+
+ARG USERNAME=node
+ARG GEMINI_CLI_PACKAGE="@google/gemini-cli"
+ARG GEMINI_CLI_VERSION=""
+
+ENV NPM_CONFIG_FUND=false \
+    NPM_CONFIG_AUDIT=false \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN --mount=type=cache,target=/home/${USERNAME}/.npm /bin/bash -euxo pipefail <<SCRIPT
+package="${GEMINI_CLI_PACKAGE}${GEMINI_CLI_VERSION:+@${GEMINI_CLI_VERSION}}"
+su "${USERNAME}" -lc "umask 0002 && npm install --global --omit=dev --loglevel=error \"\${package}\""
+su "${USERNAME}" -lc "npm cache clean --force --loglevel=error >/dev/null 2>&1 || true"
+rm -rf /home/${USERNAME}/.npm/_cacache /home/${USERNAME}/.npm/_logs || true
+SCRIPT
+
+USER ${USERNAME}
+WORKDIR /workspace
+
+ENTRYPOINT ["gemini"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary
- add a minimal `gemini-cli` image that installs the Google Gemini CLI with cleanup for smaller layers
- introduce a `gemini-cli-workbench` image extending the base CLI image with common terminal utilities
- create a publish workflow for both images and document them in the repository README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e66fcfd3c4832fa21d697a0a561864