### PR TITLE
Update Gemini agent to 0.26.0

### DIFF
--- a/.github/workflows/google-gemini-publish.yaml
+++ b/.github/workflows/google-gemini-publish.yaml
@@ -44,10 +44,10 @@ jobs:
     with:
       image-name: google-gemini-workbench
       context: ./google-gemini-docker
-      version: v0.25.0
+      version: v0.26.0
       build-args: |
         UNIVERSAL_WORKBENCH_TAG=${{ needs.resolve-universal-tag.outputs.tag }}
-        GEMINI_CLI_VERSION=0.25.0
+        GEMINI_CLI_VERSION=0.26.0
       build-contexts: |
         shared=./shared
 

--- a/google-gemini-docker/Dockerfile
+++ b/google-gemini-docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.18
 
 ARG UNIVERSAL_WORKBENCH_TAG=sha-dev
-ARG GEMINI_CLI_VERSION=0.25.0
+ARG GEMINI_CLI_VERSION=0.26.0
 ARG SPLITRAIL_VERSION=3.2.2
 
 FROM golang:1.25.5-alpine AS builder


### PR DESCRIPTION
Updated `GEMINI_CLI_VERSION` to `0.26.0` in `google-gemini-docker/Dockerfile`.
Updated `version` and `GEMINI_CLI_VERSION` in `.github/workflows/google-gemini-publish.yaml`.

---
*PR created automatically by Jules for task [1530470575340134148](https://jules.google.com/task/1530470575340134148) started by @spigell*