### PR TITLE
Update HolmesGPT to v0.19.1

### DIFF
--- a/.github/workflows/holmes-gpt-publish.yaml
+++ b/.github/workflows/holmes-gpt-publish.yaml
@@ -61,10 +61,11 @@ jobs:
     with:
       image-name: holmes-gpt
       context: ./holmes-gpt-docker
-      version: v0.16.1
+      version: v0.19.1
       build-args: |
         DEBUG_SRE_TAG=${{ needs.resolve-debug-sre-tag.outputs.tag }}
-        HOLMES_SOURCE_IMAGE=robustadev/holmes:0.16.1
+        HOLMES_SOURCE_IMAGE=robustadev/holmes:0.19.1
+        HOLMES_REF=0.19.1
       build-contexts: |
         shared=./shared
 

--- a/holmes-gpt-docker/Dockerfile
+++ b/holmes-gpt-docker/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.18
 
 ARG DEBUG_SRE_TAG=sha-dev
-ARG HOLMES_SOURCE_IMAGE=robustadev/holmes:latest
+ARG HOLMES_SOURCE_IMAGE=robustadev/holmes:0.19.1
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
-ARG HOLMES_REF=master
+ARG HOLMES_REF=0.19.1
 ARG KUBE_LINEAGE_VERSION=2.2.4
 ARG KUBE_LINEAGE_ARM_URL=https://github.com/robusta-dev/kube-lineage/releases/download/v${KUBE_LINEAGE_VERSION}/kube-lineage-macos-latest-v${KUBE_LINEAGE_VERSION}
 ARG KUBE_LINEAGE_AMD_URL=https://github.com/robusta-dev/kube-lineage/releases/download/v${KUBE_LINEAGE_VERSION}/kube-lineage-ubuntu-latest-v${KUBE_LINEAGE_VERSION}


### PR DESCRIPTION
Updated HolmesGPT to the latest stable version v0.19.1 by updating the Dockerfile and the GitHub workflow. This ensures that the workbench image is built with the latest HolmesGPT version and fetches the corresponding pyproject.toml and poetry.lock files.

---
*PR created automatically by Jules for task [8923240679192211425](https://jules.google.com/task/8923240679192211425) started by @spigell*