### PR TITLE
🧹 Extract cleanup token fetch into a separate function

### DIFF
--- a/github-runner-docker/entrypoint.sh
+++ b/github-runner-docker/entrypoint.sh
@@ -44,31 +44,24 @@ fetch_token() {
   jq -r '.token' <<<"${payload}"
 }
 
-cleanup() {
-  if [[ -f ".runner" ]]; then
-    local token="${ACTIVE_TOKEN}"
-    if [[ -z "${token}" || "${token}" == "null" ]]; then
-      set +e
-      local payload
-      payload=$(GITHUB_URL="${GITHUB_URL}" \
+fetch_cleanup_token() {
+  local payload
+  if payload=$(GITHUB_URL="${GITHUB_URL}" \
                 GITHUB_PAT="${_PAT_VALUE}" \
                 GITHUB_HOST="${_GITHUB_HOST}" \
                 RUNNER_SCOPE="${_RUNNER_SCOPE}" \
                 GITHUB_ORG="${_GITHUB_ORG}" \
                 GITHUB_ENTERPRISE="${_GITHUB_ENTERPRISE}" \
-                /usr/local/bin/fetch-runner-token.sh 2>/dev/null)
-      local status=$?
-      set -e
-      if [[ ${status} -eq 0 ]]; then
-        set +e
-        local maybe_token
-        maybe_token=$(jq -r '.token' <<<"${payload}")
-        local jq_status=$?
-        set -e
-        if [[ ${jq_status} -eq 0 ]]; then
-          token="${maybe_token}"
-        fi
-      fi
+                /usr/local/bin/fetch-runner-token.sh 2>/dev/null); then
+    jq -r '.token' <<<"${payload}" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  if [[ -f ".runner" ]]; then
+    local token="${ACTIVE_TOKEN}"
+    if [[ -z "${token}" || "${token}" == "null" ]]; then
+      token=$(fetch_cleanup_token)
     fi
     if [[ -n "${token}" && "${token}" != "null" ]]; then
       ./config.sh remove --token "${token}" || true


### PR DESCRIPTION
🎯 **What:** The complex token fetch fallback logic in `cleanup()` that manipulated `set +e`/`set -e` manually to suppress errors has been extracted into a standalone function `fetch_cleanup_token()`.

💡 **Why:** This drastically simplifies the trap handler (`cleanup`) and ensures that ignoring non-zero exit codes from fetching logic is performed clearly via assignment condition matching (`if payload=$(...)`) rather than verbose, error-prone global error state toggling. It makes `cleanup()` straightforward and easy to read.

✅ **Verification:** Verified that Bash error states are safely preserved. Run syntax checks (`bash -n`) and `shellcheck`. A manual simulation of the function exit states demonstrated that an error fallback evaluates identically, assigning an empty string to `$token` when API fetching fails and continuing cleanly without crashing the pipeline.

✨ **Result:** The codebase is cleaner and its error boundaries inside signal handlers are tighter and idiomatic.

---
*PR created automatically by Jules for task [14406379717319688235](https://jules.google.com/task/14406379717319688235) started by @spigell*